### PR TITLE
Add extra step for Ubuntu install

### DIFF
--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -8,7 +8,15 @@ Debian
 -------
 
 First, make sure that the required packages for Qt4 development of your
-distribution are installed, for Debian and Ubuntu these are:
+distribution are installed.
+
+On recent Ubuntu releases, the `libdb4.8++-dev` package is not in the default
+repositories. However it's in the bitcoin repository, which we can add
+with:
+
+    apt-add-repository ppa:bitcoin/bitcoin
+
+Then we need to make sure our build environment is up to date. For Debian and Ubuntu:
 
 ::
 


### PR DESCRIPTION
Ubuntu 13.10 doesn't have `libdb4.8++-dev` packages by default, but they're in the bitcoin ppa. This patch adds the relevant install instructions.

Note: This could probably be even better with a fancy `ppa:` line, but as I'm currently in transit I don't quite have the chance to figure that out.
