### PR TITLE
Add libminiupnpc-dev libminiupnpc8 to install docs

### DIFF
--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -14,7 +14,7 @@ distribution are installed, for Debian and Ubuntu these are:
 
     apt-get install qt4-qmake libqt4-dev build-essential libboost-dev libboost-system-dev \
         libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev \
-        libssl-dev libdb4.8++-dev
+        libssl-dev libdb4.8++-dev libminiupnpc-dev libminiupnpc8
 
 then execute the following:
 


### PR DESCRIPTION
Looks like the install docs had some missing libraries under Ubuntu.
