### PR TITLE
"Mined" to "Minted" for StakeMint transactions & Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-MintCoin (MNT)
+**MintCoin (MNT)**
 
 MintCoin is an innovative, secure and energy efficient PoW/PoS coin. It uses a faster PoW distribution mechanism to distribute the initial coins, then after 5 weeks the coin is basically transferred to a pure PoS coin, where the generation of the coin is mainly through the PoS interests.
 
@@ -11,21 +10,22 @@ MintCoin will have a total of 70 billion coins. Initially each block will delive
 
 PoS will start after at least 20 days of holding of the coins in the wallet. With PoS, the coin is more resilient to 51% attack. 
 
-Other Specifications:
-	- 30 seconds block target
-	- 100000 - 900000 coins per block initially
-	- PoW payout will be halved every week for the first 5 weeks
-	- After 5 weeks, the PoW payout will be fixed at 1 coin per block
-	- Difficulty retargets every block 
-	- PoS variable interests:
-		- 1st year: 20%
-		- 2nd year: 15%
-		- 3rd year: 10%
-		- 4th and subsequent years: 5%
-	- Total coins will be 70 billions
-	- 4 confirmations for transaction, thus fast 2 mins confirmation for transdactions
-	- 50 confirmations for minted blocks
-	- 1% premine for bounties, giveaways, development, support and maintenance, new feature developments etc.
+**Other Specifications:**
 
-	- Ports: 12788 (connection) and 12789 (RPC)
+- 30 seconds block target
+- 100000 - 900000 coins per block initially
+- PoW payout will be halved every week for the first 5 weeks
+- ~~After 5 weeks, the PoW payout will be fixed at 1 coin per block~~ PoW completely remvoed from block 220000
+- Difficulty retargets every block 
+- PoS variable interests:
+	- 1st year: 20%
+	- 2nd year: 15%
+	- 3rd year: 10%
+	- 4th and subsequent years: 5%
+- Total coins will be 70 billions
+- 4 confirmations for transaction, thus fast 2 mins confirmation for transdactions
+- 50 confirmations for minted blocks
+- 1% premine for bounties, giveaways, development, support and maintenance, new feature developments etc.
+
+- Ports: 12788 (connection) and 12789 (RPC)
 

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -1909,6 +1909,11 @@ Address: %4
         <translation>Mined</translation>
     </message>
     <message>
+        <location line="+2"/>
+        <source>Minted</source>
+        <translation>Minted</translation>
+    </message>
+    <message>
         <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
@@ -1996,6 +2001,11 @@ Address: %4
         <location line="+1"/>
         <source>Mined</source>
         <translation>Mined</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Minted</source>
+        <translation>Minted</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -74,7 +74,7 @@ TransactionView::TransactionView(QWidget *parent) :
     typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
                                   TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
-    typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::StakeMint));
+    typeWidget->addItem(tr("Minted"), TransactionFilterProxy::TYPE(TransactionRecord::StakeMint));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 


### PR DESCRIPTION
I am a noob so this could be completely wrong and not work. As noted in this reddit thread it makes more sense to say "Minted": http://www.reddit.com/r/MintCoin/comments/22818m/mint_wallet_mining_by_itself_wtf_is_going_on/

Also Readme update with fixed markup and PoW removal info.
