### PR TITLE
Remove misbehaving peer's reported block count from peer block counts wh...

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -586,6 +586,8 @@ bool CNode::IsBanned(CNetAddr ip)
     return fResult;
 }
 
+extern CMedianFilter<int> cPeerBlockCounts;
+
 bool CNode::Misbehaving(int howmuch)
 {
     if (addr.IsLocal())
@@ -605,6 +607,9 @@ bool CNode::Misbehaving(int howmuch)
                 setBanned[addr] = banTime;
         }
         CloseSocketDisconnect();
+
+        cPeerBlockCounts.removeLast(nStartingHeight); // remove this node's reported number of blocks
+
         return true;
     } else
         printf("Misbehaving: %s (%d -> %d)\n", addr.ToString().c_str(), nMisbehavior-howmuch, nMisbehavior);

--- a/src/util.h
+++ b/src/util.h
@@ -541,6 +541,7 @@ private:
     std::vector<T> vValues;
     std::vector<T> vSorted;
     unsigned int nSize;
+    T tInitial;
 public:
     CMedianFilter(unsigned int size, T initial_value):
         nSize(size)
@@ -548,6 +549,7 @@ public:
         vValues.reserve(size);
         vValues.push_back(initial_value);
         vSorted = vValues;
+        tInitial = initial_value;
     }
 
     void input(T value)
@@ -557,6 +559,27 @@ public:
             vValues.erase(vValues.begin());
         }
         vValues.push_back(value);
+
+        vSorted.resize(vValues.size());
+        std::copy(vValues.begin(), vValues.end(), vSorted.begin());
+        std::sort(vSorted.begin(), vSorted.end());
+    }
+
+    // remove last instance of a value
+    void removeLast(T value)
+    {
+        for (int i = vValues.size()-1; i >= 0; --i)
+        {
+            if (vValues[i] == value)
+            {
+                vValues.erase(vValues.begin()+i);
+                break;
+            }
+        }
+        if (vValues.empty())
+        {
+            vValues.push_back(tInitial);
+        }
 
         vSorted.resize(vValues.size());
         std::copy(vValues.begin(), vValues.end(), vSorted.begin());


### PR DESCRIPTION
...en disconnecting them

1.7/1.8 client already rejects blocks that are on wrong chain (>220k) and bans/disconnects sending client.

This patch removes the block height which the banned node had reported (removes from median filter), so the UI recovers as soon as invalid block is detected and client is banned (instead of requiring new client connections to override old records in median filter)
