### PR TITLE
Better fix for minting icon lagging the GUI.

### DIFF
--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -102,6 +102,8 @@ private:
 
     QMovie *syncIconMovie;
 
+    uint64 nMinMax;
+    uint64 nWeight;
     uint64 nNetworkWeight;
 
     /** Create the main UI actions. */
@@ -183,6 +185,8 @@ private slots:
 
     /** Update info about minting */
     void updateMintingIcon();
+    /** Update minting weight info */
+    void updateMintingWeights();
 };
 
 #endif


### PR DESCRIPTION
Split updating user and network weights into a separate function. Update
them only every 30 seconds.
